### PR TITLE
Add backend-free Planner Hub for activity suggestions and timeline voting

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
             <h1>Llama Community Meetup</h1>
             <p>Wilmington, NC • June 24-27, 2026</p>
             <a href="agreement.html" class="cta-button">Join the Adventure!</a>
+            <a href="planner.html" class="cta-button" style="margin-left: 0.8rem; background: linear-gradient(45deg, #00ffff, #ff00ff);">Plan Activities & Vote</a>
         </div>
     </section>
 

--- a/nav.html
+++ b/nav.html
@@ -11,6 +11,7 @@
             <li><a href="index.html#competition">Competition</a></li>
             <li><a href="agreement.html">Agreement</a></li>
             <li><a href="questionnaire.html">Questionnaire</a></li>
+            <li><a href="planner.html">Planner Hub</a></li>
             <li><a href="https://www.paypal.com/pool/9m0WwqqE03?sr=ancr">Contribute</a></li>
             <li><a href="gallery.html">Gallery</a></li>
             <li><a href="merch.html">Merch</a></li>

--- a/planner.html
+++ b/planner.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Trip Planner Hub - Wilmington 2026</title>
+    <link rel="stylesheet" href="style.css?v=3">
+</head>
+<body>
+    <div id="nav-placeholder"></div>
+
+    <script>
+        fetch('nav.html')
+            .then(response => response.text())
+            .then(data => {
+                document.getElementById('nav-placeholder').innerHTML = data;
+
+                const currentPage = window.location.pathname.split('/').pop() || 'index.html';
+                const navLinks = document.querySelectorAll('nav a');
+                navLinks.forEach(link => {
+                    if (link.getAttribute('href') === currentPage) {
+                        link.style.color = '#ffff00';
+                    }
+                });
+            });
+    </script>
+
+    <main class="planner-page">
+        <section class="planner-hero">
+            <h1>Wilmington Trip Planner Hub</h1>
+            <p>Suggest activities, comment on ideas, and vote on the June 24-27 timeline.</p>
+            <p class="planner-subtitle">Built for GitHub Pages (no backend required).</p>
+        </section>
+
+        <section class="planner-section">
+            <h2>How this works</h2>
+            <ol>
+                <li>Drop an activity suggestion in the <strong>Activity Suggestions</strong> thread.</li>
+                <li>Reply to discuss details, costs, and logistics.</li>
+                <li>Vote by reacting with <strong>👍</strong> to comments you support.</li>
+                <li>Use the <strong>Timeline Poll</strong> thread to vote on when each activity should happen between June 24 and June 27.</li>
+            </ol>
+            <p class="planner-note">You will need a GitHub account to comment and vote.</p>
+        </section>
+
+        <section class="planner-section">
+            <h2>1) Activity Suggestions + Discussion + Voting</h2>
+            <p>Post one activity per comment. Add links, expected cost, and best time of day. Everyone can reply and react with 👍 to vote.</p>
+            <div id="activity-thread" class="thread-shell"></div>
+            <p class="thread-fallback">If the embed doesn't load, open it directly on GitHub: <a href="https://github.com/atomsmasher101/atomsmasher101.github.io/issues?q=is%3Aissue+is%3Aopen+%22Wilmington+Trip+Activities%22" target="_blank" rel="noopener noreferrer">Activity thread</a>.</p>
+        </section>
+
+        <section class="planner-section">
+            <h2>2) Timeline Poll (June 24-27)</h2>
+            <p>Vote on which day each activity belongs on. Use comments for schedule proposals and react with 👍 to vote on each proposal.</p>
+            <ul class="timeline-options">
+                <li><strong>June 24 (Wed):</strong> Arrival + easy evening options</li>
+                <li><strong>June 25 (Thu):</strong> Downtown + challenge-friendly activities</li>
+                <li><strong>June 26 (Fri):</strong> Beach day + nightlife</li>
+                <li><strong>June 27 (Sat):</strong> Wrap-up / brunch / departures</li>
+            </ul>
+            <div id="timeline-thread" class="thread-shell"></div>
+            <p class="thread-fallback">If the embed doesn't load, open it directly on GitHub: <a href="https://github.com/atomsmasher101/atomsmasher101.github.io/issues?q=is%3Aissue+is%3Aopen+%22Wilmington+Trip+Timeline+Poll%22" target="_blank" rel="noopener noreferrer">Timeline poll thread</a>.</p>
+        </section>
+    </main>
+
+    <script>
+        function injectUtterances(containerId, issueTerm) {
+            const container = document.getElementById(containerId);
+            const script = document.createElement('script');
+            script.src = 'https://utteranc.es/client.js';
+            script.setAttribute('repo', 'atomsmasher101/atomsmasher101.github.io');
+            script.setAttribute('issue-term', issueTerm);
+            script.setAttribute('label', 'trip-planning');
+            script.setAttribute('theme', 'github-dark');
+            script.setAttribute('crossorigin', 'anonymous');
+            script.async = true;
+            container.appendChild(script);
+        }
+
+        injectUtterances('activity-thread', 'Wilmington Trip Activities');
+        injectUtterances('timeline-thread', 'Wilmington Trip Timeline Poll');
+    </script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1781,3 +1781,78 @@ body.success-page {
         font-size: 0.8rem;
     }
 }
+
+/* ============================================
+   TRIP PLANNER HUB STYLES
+   ============================================ */
+.planner-page {
+    max-width: 1000px;
+    margin: 0 auto 5rem;
+    padding: 2rem 1.2rem 0;
+}
+
+.planner-hero {
+    text-align: center;
+    margin-bottom: 2.5rem;
+}
+
+.planner-hero h1 {
+    font-size: clamp(2rem, 5vw, 3rem);
+    margin-bottom: 0.8rem;
+}
+
+.planner-subtitle {
+    color: #ffff00;
+}
+
+.planner-section {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(0, 255, 255, 0.35);
+    border-radius: 14px;
+    padding: 1.4rem;
+    margin-bottom: 1.5rem;
+    box-shadow: 0 0 24px rgba(0, 255, 255, 0.08);
+}
+
+.planner-section h2 {
+    color: #00ffff;
+    margin-bottom: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.planner-note {
+    color: #ffff00;
+    margin-top: 0.8rem;
+}
+
+.planner-section ol,
+.planner-section ul {
+    margin-left: 1.2rem;
+}
+
+.timeline-options {
+    margin-top: 0.8rem;
+}
+
+.thread-shell {
+    margin-top: 1rem;
+    min-height: 220px;
+    border: 1px dashed rgba(255, 0, 255, 0.4);
+    border-radius: 10px;
+    padding: 0.7rem;
+    background: rgba(0, 0, 0, 0.45);
+}
+
+.thread-fallback {
+    margin-top: 0.8rem;
+    font-size: 0.95rem;
+}
+
+.thread-fallback a {
+    color: #00ffff;
+}
+
+.thread-fallback a:hover {
+    color: #ff00ff;
+}


### PR DESCRIPTION
### Motivation
- Provide attendees a simple place to suggest activities, discuss them, and vote on a June 24–27 timeline without adding server-side infrastructure. 
- Leverage GitHub Pages limitations by using GitHub Issues as the comment/vote backend via Utterances so reactions (👍) act as votes.

### Description
- Added a new `planner.html` page that embeds two Utterances threads for `Wilmington Trip Activities` and `Wilmington Trip Timeline Poll` to handle suggestions, discussion, and voting. 
- The Utterances embed is configured to use the repository `atomsmasher101/atomsmasher101.github.io` and includes fallback links to the corresponding GitHub issue searches. 
- Exposed the page site-wide by adding a `Planner Hub` link to `nav.html` and adding a second hero CTA on `index.html` that links to `planner.html`. 
- Added planner-specific styles to `style.css` for layout, thread containers, and responsive presentation.

### Testing
- Ran `git diff -- nav.html index.html planner.html style.css` to confirm the intended file changes; the diff output matched the new `planner.html` and updates to `nav.html`, `index.html`, and `style.css` and succeeded. 
- Inspected the new and updated files with `nl -ba planner.html | sed -n '1,240p' && nl -ba nav.html | sed -n '1,80p' && nl -ba index.html | sed -n '30,60p' && nl -ba style.css | sed -n '1780,1885p'` to verify content and succeeded. 
- Verified working tree status with `git status --short` and found no outstanding changes; the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e432695e78832c9a309f57d0c2ef87)