### PR TITLE
Update homepage with house member assignments

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,8 +102,8 @@
                     <img src="https://a0.muscache.com/im/pictures/miso/Hosting-869500486520368451/original/496cf59a-6a8b-4b1c-bc91-33fdbd8d2e7f.jpeg?aki_policy=xx_large" alt="House A Exterior">
                 </div>
                 <div class="house-header">
-                    <h3>🦙 House A</h3>
-                    <p>Team TBD</p>
+                    <h3>⚛️ House Atom</h3>
+                    <p>Atom, Nash, and Birdie</p>
                 </div>
                 <div class="house-body">
                     <p><strong>Location:</strong> 905 Walnut St (Unit A)</p>
@@ -117,8 +117,8 @@
                     <img src="https://a0.muscache.com/im/pictures/miso/Hosting-869498961852746437/original/f233641d-9ca6-4114-8cbb-d84a288bf1c9.jpeg?aki_policy=xx_large" alt="House B Exterior">
                 </div>
                 <div class="house-header">
-                    <h3>🦙 House B</h3>
-                    <p>Team TBD</p>
+                    <h3>🦙 House Llama</h3>
+                    <p>Llama &amp; Mizers, Nate &amp; Harmony, and Keekz</p>
                 </div>
                 <div class="house-body">
                     <p><strong>Location:</strong> 905 Walnut St (Unit B)</p>


### PR DESCRIPTION
### Motivation
- Replace placeholder team labels in the Houses section with the actual house names and member lists so visitors can see who is assigned to each house.

### Description
- Change the House A header and team text to `⚛️ House Atom` with members `Atom, Nash, and Birdie` in `index.html`.
- Change the House B header and team text to `🦙 House Llama` with members `Llama & Mizers, Nate & Harmony, and Keekz` in `index.html`.
- This change only updates the home page `index.html` file and does not alter other pages or assets.

### Testing
- Executed the update via a small `python` replacement script which completed successfully.
- Inspected the file content with `sed -n '1,220p' index.html` to review the page and with `nl -ba index.html | sed -n '96,132p'` to verify the exact modified lines, and both showed the expected house names and member lists.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e43344369c832c94519fbe89e25458)