### PR TITLE
Add Cloudflare Worker backend and client UI for planner voting & timelines

### DIFF
--- a/planner.html
+++ b/planner.html
@@ -7,7 +7,7 @@
     <meta http-equiv="Expires" content="0">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Trip Planner Hub - Wilmington 2026</title>
-    <link rel="stylesheet" href="style.css?v=3">
+    <link rel="stylesheet" href="style.css?v=4">
 </head>
 <body>
     <div id="nav-placeholder"></div>
@@ -31,66 +31,397 @@
     <main class="planner-page">
         <section class="planner-hero">
             <h1>Wilmington Trip Planner Hub</h1>
-            <p>Suggest activities, comment on ideas, and vote on the June 24-27 timeline.</p>
-            <p class="planner-subtitle">Let Atom know if this is too complicated lol.</p>
+            <p>Custom activity submissions, voting, and timeline planning powered by a Cloudflare Worker.</p>
+            <p class="planner-subtitle">No GitHub account required anymore.</p>
         </section>
 
         <section class="planner-section">
-            <h2>How this works</h2>
-            <ol>
-                <li>Drop an activity suggestion in the <strong>Activity Suggestions</strong> thread.</li>
-                <li>Reply to discuss details, costs, and logistics.</li>
-                <li>Vote by reacting with <strong>👍</strong> to comments you support.</li>
-                <li>Use the <strong>Timeline Poll</strong> thread to vote on when each activity should happen between June 24 and June 27.</li>
-            </ol>
-            <p class="planner-note">You will need a GitHub account to comment and vote.</p>
-        </section>
-
-        <section class="planner-section">
-            <h2>1) Activity Suggestions + Discussion + Voting</h2>
-            <p>Post one activity per comment. Add links, expected cost, and best time of day. Everyone can reply and react with 👍 to vote.</p>
-            <div id="activity-thread" class="thread-shell"></div>
-            <div class="reply-help">
-                <p><strong>Need direct replies?</strong> Open the full GitHub thread and use <strong>Quote reply</strong> or <strong>Reply</strong> under the specific comment.</p>
-                <a class="reply-link" href="https://github.com/atomsmasher101/atomsmasher101.github.io/issues?q=is%3Aissue+is%3Aopen+%22Wilmington+Trip+Activities%22" target="_blank" rel="noopener noreferrer">Open Activity Thread on GitHub ↗</a>
+            <h2>Cloudflare Worker Setup</h2>
+            <p>Set your Worker URL below. Example: <code>https://trip-planner-api.your-subdomain.workers.dev</code></p>
+            <div class="api-config">
+                <label for="worker-url">Worker Base URL</label>
+                <input id="worker-url" type="url" placeholder="https://trip-planner-api.your-subdomain.workers.dev">
+                <button id="save-worker-url" type="button">Save URL</button>
             </div>
-            <p class="thread-fallback">If the embed doesn't load, open it directly on GitHub: <a href="https://github.com/atomsmasher101/atomsmasher101.github.io/issues?q=is%3Aissue+is%3Aopen+%22Wilmington+Trip+Activities%22" target="_blank" rel="noopener noreferrer">Activity thread</a>.</p>
+            <p class="planner-note">Tip: this is stored locally in your browser. Each person can use the same URL.</p>
         </section>
 
         <section class="planner-section">
-            <h2>2) Timeline Poll (June 24-27)</h2>
-            <p>Vote on which day each activity belongs on. Use comments for schedule proposals and react with 👍 to vote on each proposal.</p>
-            <p class="planner-note">Reply to individual proposals in the GitHub thread to keep timeline debates organized.</p>
-            <ul class="timeline-options">
-                <li><strong>June 24 (Wed):</strong> Arrival + easy evening options</li>
-                <li><strong>June 25 (Thu):</strong> Downtown + challenge-friendly activities</li>
-                <li><strong>June 26 (Fri):</strong> Beach day + nightlife</li>
-                <li><strong>June 27 (Sat):</strong> Wrap-up / brunch / departures</li>
-            </ul>
-            <div id="timeline-thread" class="thread-shell"></div>
-            <div class="reply-help">
-                <a class="reply-link" href="https://github.com/atomsmasher101/atomsmasher101.github.io/issues?q=is%3Aissue+is%3Aopen+%22Wilmington+Trip+Timeline+Poll%22" target="_blank" rel="noopener noreferrer">Open Timeline Thread on GitHub ↗</a>
-            </div>
-            <p class="thread-fallback">If the embed doesn't load, open it directly on GitHub: <a href="https://github.com/atomsmasher101/atomsmasher101.github.io/issues?q=is%3Aissue+is%3Aopen+%22Wilmington+Trip+Timeline+Poll%22" target="_blank" rel="noopener noreferrer">Timeline poll thread</a>.</p>
+            <h2>1) Submit Activity Suggestions</h2>
+            <form id="activity-form" class="planner-form">
+                <div class="form-row">
+                    <label for="activity-title">Activity title</label>
+                    <input id="activity-title" maxlength="120" required placeholder="Example: Riverwalk + dinner crawl">
+                </div>
+                <div class="form-row">
+                    <label for="activity-description">Description</label>
+                    <textarea id="activity-description" rows="3" maxlength="600" placeholder="What is it, cost estimate, group size, travel notes?"></textarea>
+                </div>
+                <div class="form-row form-row-inline">
+                    <div>
+                        <label for="activity-author">Your name (optional)</label>
+                        <input id="activity-author" maxlength="80" placeholder="Name or handle">
+                    </div>
+                    <button type="submit">Submit Activity</button>
+                </div>
+            </form>
+            <p id="activity-form-status" class="form-status" aria-live="polite"></p>
+        </section>
+
+        <section class="planner-section">
+            <h2>2) Vote + Threaded Discussion</h2>
+            <p>Each suggestion has votes and its own reply thread.</p>
+            <div id="activity-list" class="activity-list"></div>
+        </section>
+
+        <section class="planner-section">
+            <h2>3) Visual Timeline Suggestions</h2>
+            <p>Assign suggested activities to days and time ranges.</p>
+            <form id="timeline-form" class="planner-form">
+                <div class="form-row form-row-inline form-row-three">
+                    <div>
+                        <label for="timeline-activity">Activity</label>
+                        <select id="timeline-activity" required></select>
+                    </div>
+                    <div>
+                        <label for="timeline-day">Day</label>
+                        <select id="timeline-day" required>
+                            <option value="2026-06-24">June 24 (Wed)</option>
+                            <option value="2026-06-25">June 25 (Thu)</option>
+                            <option value="2026-06-26">June 26 (Fri)</option>
+                            <option value="2026-06-27">June 27 (Sat)</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label for="timeline-author">Name (optional)</label>
+                        <input id="timeline-author" maxlength="80" placeholder="Name or handle">
+                    </div>
+                </div>
+                <div class="form-row form-row-inline">
+                    <div>
+                        <label for="timeline-start">Start time</label>
+                        <input id="timeline-start" type="time" required>
+                    </div>
+                    <div>
+                        <label for="timeline-end">End time</label>
+                        <input id="timeline-end" type="time" required>
+                    </div>
+                    <button type="submit">Add Timeline Suggestion</button>
+                </div>
+            </form>
+            <p id="timeline-form-status" class="form-status" aria-live="polite"></p>
+            <div id="timeline-grid" class="timeline-grid"></div>
+        </section>
+
+        <section class="planner-section">
+            <h2>4) Master Timeline (Aggregated)</h2>
+            <p>Higher bars = more suggested overlap for that activity + slot.</p>
+            <div id="master-timeline" class="master-timeline"></div>
         </section>
     </main>
 
     <script>
-        function injectUtterances(containerId, issueTerm) {
-            const container = document.getElementById(containerId);
-            const script = document.createElement('script');
-            script.src = 'https://utteranc.es/client.js';
-            script.setAttribute('repo', 'atomsmasher101/atomsmasher101.github.io');
-            script.setAttribute('issue-term', issueTerm);
-            script.setAttribute('label', 'trip-planning');
-            script.setAttribute('theme', 'github-dark');
-            script.setAttribute('crossorigin', 'anonymous');
-            script.async = true;
-            container.appendChild(script);
+        const STORAGE_KEY = 'plannerWorkerBaseUrl';
+        const defaultWorkerUrl = 'https://trip-planner-api.your-subdomain.workers.dev';
+
+        const workerUrlInput = document.getElementById('worker-url');
+        const saveWorkerButton = document.getElementById('save-worker-url');
+        const activityForm = document.getElementById('activity-form');
+        const timelineForm = document.getElementById('timeline-form');
+        const activityList = document.getElementById('activity-list');
+        const timelineGrid = document.getElementById('timeline-grid');
+        const masterTimeline = document.getElementById('master-timeline');
+        const activitySelect = document.getElementById('timeline-activity');
+
+        let activitiesCache = [];
+
+        function getWorkerBaseUrl() {
+            const saved = localStorage.getItem(STORAGE_KEY);
+            return saved || defaultWorkerUrl;
         }
 
-        injectUtterances('activity-thread', 'Wilmington Trip Activities');
-        injectUtterances('timeline-thread', 'Wilmington Trip Timeline Poll');
+        function setFormStatus(id, message, isError = false) {
+            const el = document.getElementById(id);
+            el.textContent = message;
+            el.classList.toggle('error', isError);
+        }
+
+        function formatDate(day) {
+            return new Date(`${day}T00:00:00`).toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+        }
+
+        async function api(path, options = {}) {
+            const base = getWorkerBaseUrl().replace(/\/$/, '');
+            const response = await fetch(`${base}${path}`, {
+                headers: {
+                    'Content-Type': 'application/json',
+                    ...(options.headers || {})
+                },
+                ...options
+            });
+
+            if (!response.ok) {
+                const text = await response.text();
+                throw new Error(text || `Request failed: ${response.status}`);
+            }
+
+            return response.json();
+        }
+
+        function renderActivitySelector() {
+            activitySelect.innerHTML = '';
+            if (!activitiesCache.length) {
+                const option = document.createElement('option');
+                option.value = '';
+                option.textContent = 'Submit an activity first';
+                activitySelect.appendChild(option);
+                return;
+            }
+
+            activitiesCache.forEach(activity => {
+                const option = document.createElement('option');
+                option.value = activity.id;
+                option.textContent = `${activity.title} (${activity.votes} votes)`;
+                activitySelect.appendChild(option);
+            });
+        }
+
+        function buildCommentNode(comment) {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'comment-item';
+            wrapper.innerHTML = `
+                <p><strong>${comment.author || 'Anonymous'}</strong> · ${new Date(comment.createdAt).toLocaleString()}</p>
+                <p>${comment.body}</p>
+            `;
+            return wrapper;
+        }
+
+        function buildTimelineBlocks(timelineEntries) {
+            const byDay = timelineEntries.reduce((acc, entry) => {
+                acc[entry.day] = acc[entry.day] || [];
+                acc[entry.day].push(entry);
+                return acc;
+            }, {});
+
+            timelineGrid.innerHTML = '';
+
+            ['2026-06-24', '2026-06-25', '2026-06-26', '2026-06-27'].forEach(day => {
+                const dayCard = document.createElement('div');
+                dayCard.className = 'timeline-day';
+                const entries = (byDay[day] || []).sort((a, b) => a.startTime.localeCompare(b.startTime));
+                dayCard.innerHTML = `<h3>${formatDate(day)}</h3>`;
+
+                if (!entries.length) {
+                    const empty = document.createElement('p');
+                    empty.className = 'planner-note';
+                    empty.textContent = 'No suggestions yet.';
+                    dayCard.appendChild(empty);
+                } else {
+                    entries.forEach(entry => {
+                        const block = document.createElement('div');
+                        block.className = 'timeline-block';
+                        block.innerHTML = `
+                            <p><strong>${entry.title}</strong></p>
+                            <p>${entry.startTime} - ${entry.endTime}</p>
+                            <p>by ${entry.author || 'Anonymous'}</p>
+                        `;
+                        dayCard.appendChild(block);
+                    });
+                }
+
+                timelineGrid.appendChild(dayCard);
+            });
+        }
+
+        function buildMasterTimeline(masterRows) {
+            masterTimeline.innerHTML = '';
+            if (!masterRows.length) {
+                masterTimeline.innerHTML = '<p class="planner-note">No aggregate data yet.</p>';
+                return;
+            }
+
+            masterRows.forEach(row => {
+                const item = document.createElement('div');
+                item.className = 'master-row';
+                const intensity = Math.max(10, Math.min(100, row.totalVotes * 10));
+                item.innerHTML = `
+                    <div class="master-row-header">
+                        <strong>${row.title}</strong>
+                        <span>${formatDate(row.day)} · ${row.startTime}-${row.endTime}</span>
+                    </div>
+                    <div class="master-meter">
+                        <div class="master-meter-fill" style="width:${intensity}%"></div>
+                    </div>
+                    <p>${row.totalVotes} timeline suggestions</p>
+                `;
+                masterTimeline.appendChild(item);
+            });
+        }
+
+        async function loadComments(activityId, container) {
+            container.innerHTML = '<p>Loading replies...</p>';
+            try {
+                const { comments } = await api(`/api/activities/${activityId}/comments`);
+                container.innerHTML = '';
+                if (!comments.length) {
+                    container.innerHTML = '<p class="planner-note">No replies yet.</p>';
+                    return;
+                }
+                comments.forEach(comment => container.appendChild(buildCommentNode(comment)));
+            } catch (error) {
+                container.innerHTML = `<p class="error">Failed to load replies: ${error.message}</p>`;
+            }
+        }
+
+        function renderActivities(activities) {
+            activityList.innerHTML = '';
+
+            if (!activities.length) {
+                activityList.innerHTML = '<p class="planner-note">No activities yet. Be the first to submit one.</p>';
+                return;
+            }
+
+            activities.forEach(activity => {
+                const card = document.createElement('article');
+                card.className = 'activity-card';
+                card.innerHTML = `
+                    <h3>${activity.title}</h3>
+                    <p>${activity.description || 'No description provided.'}</p>
+                    <p class="meta">Submitted by ${activity.author || 'Anonymous'} · ${new Date(activity.createdAt).toLocaleString()}</p>
+                    <div class="activity-actions">
+                        <button type="button" data-vote-id="${activity.id}">👍 ${activity.votes}</button>
+                    </div>
+                    <form class="comment-form" data-comment-id="${activity.id}">
+                        <input name="author" maxlength="80" placeholder="Name (optional)">
+                        <input name="body" maxlength="500" required placeholder="Add a reply for this activity thread...">
+                        <button type="submit">Reply</button>
+                    </form>
+                    <div class="comments" id="comments-${activity.id}"></div>
+                `;
+                activityList.appendChild(card);
+                loadComments(activity.id, card.querySelector(`#comments-${activity.id}`));
+            });
+
+            document.querySelectorAll('[data-vote-id]').forEach(button => {
+                button.addEventListener('click', async () => {
+                    try {
+                        await api(`/api/activities/${button.dataset.voteId}/vote`, { method: 'POST' });
+                        await refreshEverything();
+                    } catch (error) {
+                        alert(`Unable to vote: ${error.message}`);
+                    }
+                });
+            });
+
+            document.querySelectorAll('[data-comment-id]').forEach(form => {
+                form.addEventListener('submit', async event => {
+                    event.preventDefault();
+                    const id = form.dataset.commentId;
+                    const data = new FormData(form);
+                    const body = data.get('body');
+                    const author = data.get('author');
+
+                    try {
+                        await api(`/api/activities/${id}/comments`, {
+                            method: 'POST',
+                            body: JSON.stringify({ body, author })
+                        });
+                        form.reset();
+                        const commentsContainer = document.getElementById(`comments-${id}`);
+                        await loadComments(id, commentsContainer);
+                    } catch (error) {
+                        alert(`Unable to submit reply: ${error.message}`);
+                    }
+                });
+            });
+        }
+
+        async function refreshEverything() {
+            const [activitiesData, timelineData, masterData] = await Promise.all([
+                api('/api/activities'),
+                api('/api/timeline-entries'),
+                api('/api/timeline/master')
+            ]);
+
+            activitiesCache = activitiesData.activities;
+            renderActivities(activitiesCache);
+            renderActivitySelector();
+            buildTimelineBlocks(timelineData.entries);
+            buildMasterTimeline(masterData.rows);
+        }
+
+        saveWorkerButton.addEventListener('click', async () => {
+            const value = workerUrlInput.value.trim();
+            if (!value) {
+                alert('Please enter a Worker URL first.');
+                return;
+            }
+
+            localStorage.setItem(STORAGE_KEY, value);
+            await refreshEverything();
+            alert('Worker URL saved.');
+        });
+
+        activityForm.addEventListener('submit', async event => {
+            event.preventDefault();
+            const payload = {
+                title: document.getElementById('activity-title').value.trim(),
+                description: document.getElementById('activity-description').value.trim(),
+                author: document.getElementById('activity-author').value.trim()
+            };
+
+            try {
+                await api('/api/activities', {
+                    method: 'POST',
+                    body: JSON.stringify(payload)
+                });
+                activityForm.reset();
+                setFormStatus('activity-form-status', 'Activity submitted.');
+                await refreshEverything();
+            } catch (error) {
+                setFormStatus('activity-form-status', `Could not submit: ${error.message}`, true);
+            }
+        });
+
+        timelineForm.addEventListener('submit', async event => {
+            event.preventDefault();
+
+            const payload = {
+                activityId: Number(activitySelect.value),
+                day: document.getElementById('timeline-day').value,
+                startTime: document.getElementById('timeline-start').value,
+                endTime: document.getElementById('timeline-end').value,
+                author: document.getElementById('timeline-author').value.trim()
+            };
+
+            if (!payload.activityId) {
+                setFormStatus('timeline-form-status', 'Pick an activity first.', true);
+                return;
+            }
+
+            if (payload.endTime <= payload.startTime) {
+                setFormStatus('timeline-form-status', 'End time must be after start time.', true);
+                return;
+            }
+
+            try {
+                await api('/api/timeline-entries', {
+                    method: 'POST',
+                    body: JSON.stringify(payload)
+                });
+                timelineForm.reset();
+                setFormStatus('timeline-form-status', 'Timeline suggestion submitted.');
+                await refreshEverything();
+            } catch (error) {
+                setFormStatus('timeline-form-status', `Could not submit: ${error.message}`, true);
+            }
+        });
+
+        workerUrlInput.value = getWorkerBaseUrl();
+        refreshEverything().catch(error => {
+            setFormStatus('activity-form-status', `Initial load failed: ${error.message}`, true);
+            setFormStatus('timeline-form-status', `Initial load failed: ${error.message}`, true);
+        });
     </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1786,7 +1786,7 @@ body.success-page {
    TRIP PLANNER HUB STYLES
    ============================================ */
 .planner-page {
-    max-width: 1000px;
+    max-width: 1100px;
     margin: 0 auto 5rem;
     padding: 2rem 1.2rem 0;
 }
@@ -1826,59 +1826,187 @@ body.success-page {
     margin-top: 0.8rem;
 }
 
-.planner-section ol,
-.planner-section ul {
-    margin-left: 1.2rem;
+.api-config {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.8rem;
+    align-items: end;
 }
 
-.timeline-options {
-    margin-top: 0.8rem;
+.api-config label {
+    grid-column: 1 / -1;
 }
 
-.thread-shell {
+.api-config button,
+.planner-form button,
+.activity-actions button,
+.comment-form button {
+    border: none;
+    background: linear-gradient(45deg, #ffff00, #00ffff);
+    color: #000;
+    font-weight: 800;
+    border-radius: 8px;
+    cursor: pointer;
+    padding: 0.65rem 1rem;
+}
+
+.api-config button:hover,
+.planner-form button:hover,
+.activity-actions button:hover,
+.comment-form button:hover {
+    background: linear-gradient(45deg, #00ffff, #ff00ff);
+}
+
+.planner-form {
     margin-top: 1rem;
-    min-height: 220px;
-    border: 1px dashed rgba(255, 0, 255, 0.4);
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+}
+
+.form-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.form-row-inline {
+    display: grid;
+    grid-template-columns: 1fr 1fr auto;
+    gap: 0.8rem;
+    align-items: end;
+}
+
+.form-row-three {
+    grid-template-columns: 1fr 1fr 1fr;
+}
+
+textarea,
+select,
+input[type="url"],
+input[type="time"] {
+    width: 100%;
+    padding: 0.8rem;
+    background: rgba(255, 0, 255, 0.08);
+    border: 1px solid rgba(255, 0, 255, 0.5);
     border-radius: 10px;
-    padding: 0.7rem;
-    background: rgba(0, 0, 0, 0.45);
+    color: #fff;
+    font-weight: 600;
 }
 
-.thread-fallback {
-    margin-top: 0.8rem;
+.form-status {
+    margin-top: 0.6rem;
     font-size: 0.95rem;
-}
-
-.thread-fallback a {
     color: #00ffff;
 }
 
-.thread-fallback a:hover {
-    color: #ff00ff;
+.error {
+    color: #ff8fa3;
 }
 
-.reply-help {
-    margin-top: 0.9rem;
-    padding: 0.8rem;
-    border-radius: 10px;
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 0, 0.25);
+.activity-list {
+    display: grid;
+    gap: 1rem;
 }
 
-.reply-help p {
-    margin-bottom: 0.6rem;
+.activity-card {
+    border: 1px solid rgba(255, 255, 0, 0.35);
+    border-radius: 12px;
+    padding: 1rem;
+    background: rgba(0, 0, 0, 0.4);
 }
 
-.reply-link {
-    display: inline-block;
-    color: #000;
-    text-decoration: none;
-    font-weight: 800;
-    background: linear-gradient(45deg, #ffff00, #00ffff);
-    padding: 0.45rem 0.8rem;
+.activity-card .meta {
+    color: #00ffff;
+    font-size: 0.9rem;
+}
+
+.activity-actions {
+    margin: 0.8rem 0;
+}
+
+.comment-form {
+    display: grid;
+    grid-template-columns: 1fr 2fr auto;
+    gap: 0.6rem;
+    margin-bottom: 0.8rem;
+}
+
+.comments {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.comment-item {
+    border: 1px solid rgba(0, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.02);
     border-radius: 8px;
+    padding: 0.6rem;
 }
 
-.reply-link:hover {
+.timeline-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.8rem;
+    margin-top: 1rem;
+}
+
+.timeline-day {
+    border: 1px dashed rgba(255, 0, 255, 0.4);
+    border-radius: 10px;
+    padding: 0.8rem;
+    background: rgba(0, 0, 0, 0.45);
+}
+
+.timeline-day h3 {
+    margin-bottom: 0.6rem;
+    font-size: 1.1rem;
+}
+
+.timeline-block {
+    background: rgba(0, 255, 255, 0.08);
+    border: 1px solid rgba(0, 255, 255, 0.4);
+    border-radius: 8px;
+    padding: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.master-timeline {
+    display: grid;
+    gap: 0.8rem;
+}
+
+.master-row {
+    border: 1px solid rgba(255, 255, 0, 0.3);
+    border-radius: 10px;
+    padding: 0.8rem;
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.master-row-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.master-meter {
+    height: 12px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.15);
+    margin: 0.5rem 0;
+    overflow: hidden;
+}
+
+.master-meter-fill {
+    height: 100%;
     background: linear-gradient(45deg, #00ffff, #ff00ff);
+}
+
+@media (max-width: 768px) {
+    .form-row-inline,
+    .comment-form,
+    .api-config {
+        grid-template-columns: 1fr;
+    }
 }

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,44 @@
+# Trip Planner Cloudflare Worker Backend
+
+This Worker provides a custom backend for:
+- activity suggestions with votes,
+- per-activity threaded replies,
+- visual timeline suggestions (day + time ranges),
+- and an aggregated master timeline.
+
+## 1) Create D1 DB + apply schema
+
+```bash
+cd worker
+npx wrangler d1 create trip_planner
+# copy database_id into wrangler.toml
+npx wrangler d1 execute trip_planner --file=./schema.sql
+```
+
+## 2) Run locally
+
+```bash
+npx wrangler dev
+```
+
+## 3) Deploy
+
+```bash
+npx wrangler deploy
+```
+
+## API Endpoints
+
+- `GET /api/health`
+- `GET /api/activities`
+- `POST /api/activities`
+- `POST /api/activities/:id/vote`
+- `GET /api/activities/:id/comments`
+- `POST /api/activities/:id/comments`
+- `GET /api/timeline-entries`
+- `POST /api/timeline-entries`
+- `GET /api/timeline/master`
+
+## Frontend wiring
+
+`planner.html` includes a "Worker Base URL" field. Set it to your deployed Worker URL and save.

--- a/worker/schema.sql
+++ b/worker/schema.sql
@@ -1,0 +1,32 @@
+CREATE TABLE IF NOT EXISTS activities (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  title TEXT NOT NULL,
+  description TEXT,
+  author TEXT,
+  votes INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS comments (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  activity_id INTEGER NOT NULL,
+  author TEXT,
+  body TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY(activity_id) REFERENCES activities(id)
+);
+
+CREATE TABLE IF NOT EXISTS timeline_entries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  activity_id INTEGER NOT NULL,
+  day TEXT NOT NULL,
+  start_time TEXT NOT NULL,
+  end_time TEXT NOT NULL,
+  author TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY(activity_id) REFERENCES activities(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_activities_votes ON activities(votes DESC, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_comments_activity ON comments(activity_id, created_at ASC);
+CREATE INDEX IF NOT EXISTS idx_timeline_day_start ON timeline_entries(day, start_time);

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,0 +1,180 @@
+export default {
+  async fetch(request, env) {
+    if (request.method === 'OPTIONS') {
+      return withCors(new Response(null, { status: 204 }));
+    }
+
+    const url = new URL(request.url);
+
+    try {
+      if (url.pathname === '/api/health' && request.method === 'GET') {
+        return json({ ok: true });
+      }
+
+      if (url.pathname === '/api/activities' && request.method === 'GET') {
+        const rows = await env.DB
+          .prepare(`
+            SELECT id, title, description, author, votes, created_at AS createdAt
+            FROM activities
+            ORDER BY votes DESC, created_at DESC
+          `)
+          .all();
+
+        return json({ activities: rows.results || [] });
+      }
+
+      if (url.pathname === '/api/activities' && request.method === 'POST') {
+        const payload = await request.json();
+        const title = String(payload.title || '').trim();
+        const description = String(payload.description || '').trim();
+        const author = String(payload.author || '').trim();
+
+        if (!title) {
+          return json({ error: 'Title is required.' }, 400);
+        }
+
+        await env.DB
+          .prepare(`
+            INSERT INTO activities (title, description, author, votes)
+            VALUES (?1, ?2, ?3, 0)
+          `)
+          .bind(title, description || null, author || null)
+          .run();
+
+        return json({ ok: true }, 201);
+      }
+
+      const voteMatch = url.pathname.match(/^\/api\/activities\/(\d+)\/vote$/);
+      if (voteMatch && request.method === 'POST') {
+        const activityId = Number(voteMatch[1]);
+
+        await env.DB
+          .prepare(`
+            UPDATE activities
+            SET votes = votes + 1
+            WHERE id = ?1
+          `)
+          .bind(activityId)
+          .run();
+
+        return json({ ok: true });
+      }
+
+      const commentsMatch = url.pathname.match(/^\/api\/activities\/(\d+)\/comments$/);
+      if (commentsMatch && request.method === 'GET') {
+        const activityId = Number(commentsMatch[1]);
+        const rows = await env.DB
+          .prepare(`
+            SELECT id, activity_id AS activityId, author, body, created_at AS createdAt
+            FROM comments
+            WHERE activity_id = ?1
+            ORDER BY created_at ASC
+          `)
+          .bind(activityId)
+          .all();
+
+        return json({ comments: rows.results || [] });
+      }
+
+      if (commentsMatch && request.method === 'POST') {
+        const activityId = Number(commentsMatch[1]);
+        const payload = await request.json();
+        const body = String(payload.body || '').trim();
+        const author = String(payload.author || '').trim();
+
+        if (!body) {
+          return json({ error: 'Comment body is required.' }, 400);
+        }
+
+        await env.DB
+          .prepare(`
+            INSERT INTO comments (activity_id, author, body)
+            VALUES (?1, ?2, ?3)
+          `)
+          .bind(activityId, author || null, body)
+          .run();
+
+        return json({ ok: true }, 201);
+      }
+
+      if (url.pathname === '/api/timeline-entries' && request.method === 'GET') {
+        const rows = await env.DB
+          .prepare(`
+            SELECT t.id, t.activity_id AS activityId, t.day, t.start_time AS startTime,
+                   t.end_time AS endTime, t.author, t.created_at AS createdAt, a.title
+            FROM timeline_entries t
+            JOIN activities a ON a.id = t.activity_id
+            ORDER BY t.day ASC, t.start_time ASC
+          `)
+          .all();
+
+        return json({ entries: rows.results || [] });
+      }
+
+      if (url.pathname === '/api/timeline-entries' && request.method === 'POST') {
+        const payload = await request.json();
+        const activityId = Number(payload.activityId);
+        const day = String(payload.day || '').trim();
+        const startTime = String(payload.startTime || '').trim();
+        const endTime = String(payload.endTime || '').trim();
+        const author = String(payload.author || '').trim();
+
+        if (!activityId || !day || !startTime || !endTime) {
+          return json({ error: 'activityId, day, startTime, and endTime are required.' }, 400);
+        }
+
+        if (endTime <= startTime) {
+          return json({ error: 'endTime must be after startTime.' }, 400);
+        }
+
+        await env.DB
+          .prepare(`
+            INSERT INTO timeline_entries (activity_id, day, start_time, end_time, author)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+          `)
+          .bind(activityId, day, startTime, endTime, author || null)
+          .run();
+
+        return json({ ok: true }, 201);
+      }
+
+      if (url.pathname === '/api/timeline/master' && request.method === 'GET') {
+        const rows = await env.DB
+          .prepare(`
+            SELECT a.title,
+                   t.day,
+                   t.start_time AS startTime,
+                   t.end_time AS endTime,
+                   COUNT(*) AS totalVotes
+            FROM timeline_entries t
+            JOIN activities a ON a.id = t.activity_id
+            GROUP BY t.activity_id, t.day, t.start_time, t.end_time
+            ORDER BY t.day ASC, t.start_time ASC, totalVotes DESC
+          `)
+          .all();
+
+        return json({ rows: rows.results || [] });
+      }
+
+      return json({ error: 'Not found' }, 404);
+    } catch (error) {
+      return json({ error: `Server error: ${error.message}` }, 500);
+    }
+  }
+};
+
+function json(payload, status = 200) {
+  return withCors(
+    new Response(JSON.stringify(payload), {
+      status,
+      headers: { 'Content-Type': 'application/json; charset=utf-8' }
+    })
+  );
+}
+
+function withCors(response) {
+  response.headers.set('Access-Control-Allow-Origin', '*');
+  response.headers.set('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  response.headers.set('Access-Control-Allow-Headers', 'Content-Type');
+  return response;
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,8 @@
+name = "trip-planner-api"
+main = "src/index.js"
+compatibility_date = "2026-04-19"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "trip_planner"
+database_id = "REPLACE_WITH_D1_DATABASE_ID"


### PR DESCRIPTION
### Motivation
- The GitHub/Utterances-based voting and timeline flow required a GitHub account and was awkward for replies, so replace it with a dedicated backend + UI for simpler submission, voting, and threaded discussion.
- Provide an interactive visual timeline and an aggregated master timeline so participants can propose day/time slots and see community interest at a glance.

### Description
- Reworked the planner page to a Cloudflare Worker-backed UI in `planner.html` that includes activity submission, per-activity threaded replies, upvoting, timeline suggestion forms (day + time range), and a master timeline aggregation, plus a browser-stored Worker base URL configuration (`localStorage`).
- Expanded planner styles in `style.css` to support the new form layouts, activity cards, comment threads, timeline grid, master timeline meters, and responsive behavior.
- Added a Cloudflare Worker implementation at `worker/src/index.js` that exposes REST endpoints with CORS handling for `GET/POST /api/activities`, `POST /api/activities/:id/vote`, `GET/POST /api/activities/:id/comments`, `GET/POST /api/timeline-entries`, `GET /api/timeline/master`, and `GET /api/health`.
- Included `worker/schema.sql`, `worker/wrangler.toml`, and `worker/README.md` to provision a D1 database schema, configure the Worker project, and document local run/deploy steps and API usage.

### Testing
- Ran a static syntax check with `node --check worker/src/index.js`, which succeeded.
- No integration or deployment tests (D1 provisioning or `wrangler deploy`) were executed in this environment; those steps are documented in `worker/README.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e43c408284832ca03c5416bcb34ecb)