### PR TITLE
Fix missing themed styling on planner text inputs

### DIFF
--- a/planner.html
+++ b/planner.html
@@ -40,7 +40,7 @@
             <form id="activity-form" class="planner-form">
                 <div class="form-row">
                     <label for="activity-title">Activity title</label>
-                    <input id="activity-title" maxlength="120" required placeholder="Example: Riverwalk + dinner crawl">
+                    <input id="activity-title" type="text" maxlength="120" required placeholder="Example: Riverwalk + dinner crawl">
                 </div>
                 <div class="form-row">
                     <label for="activity-description">Description</label>
@@ -49,7 +49,7 @@
                 <div class="form-row form-row-inline">
                     <div>
                         <label for="activity-author">Your name (optional)</label>
-                        <input id="activity-author" maxlength="80" placeholder="Name or handle">
+                        <input id="activity-author" type="text" maxlength="80" placeholder="Name or handle">
                     </div>
                     <button type="submit">Submit Activity</button>
                 </div>
@@ -83,7 +83,7 @@
                     </div>
                     <div>
                         <label for="timeline-author">Name (optional)</label>
-                        <input id="timeline-author" maxlength="80" placeholder="Name or handle">
+                        <input id="timeline-author" type="text" maxlength="80" placeholder="Name or handle">
                     </div>
                 </div>
                 <div class="form-row form-row-inline">


### PR DESCRIPTION
### Motivation
- The theme CSS targets `input[type="text"]`, but three planner form fields lacked an explicit `type` attribute so they did not receive themed styles.
- Restoring the explicit `type="text"` ensures consistent appearance across the planner forms.

### Description
- Added `type="text"` to the `Activity title` input (`#activity-title`) in `planner.html`.
- Added `type="text"` to the `Your name (optional)` input (`#activity-author`) in `planner.html`.
- Added `type="text"` to the timeline `Name (optional)` input (`#timeline-author`) in `planner.html`.
- Only `planner.html` was modified and no CSS or JavaScript behavior was changed.

### Testing
- Ran `rg -n "activity-title|activity-author|timeline-author" planner.html` to confirm the three inputs are present and include `type="text"`, which succeeded.
- Applied the automated replacement script (`python` inline edit) to update the file and verified the edits completed without error.
- Inspected the updated `planner.html` (viewed relevant lines) to confirm the new attributes are present and correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e443fd4aa0832caac6a99b8ee37760)