### PR TITLE
Fix planner vote toggling and persist per-browser vote state

### DIFF
--- a/planner.html
+++ b/planner.html
@@ -117,8 +117,26 @@
         const timelineGrid = document.getElementById('timeline-grid');
         const masterTimeline = document.getElementById('master-timeline');
         const activitySelect = document.getElementById('timeline-activity');
+        const VOTED_ACTIVITIES_STORAGE_KEY = 'plannerVotedActivities';
 
         let activitiesCache = [];
+        let votedActivities = loadVotedActivities();
+
+        function loadVotedActivities() {
+            try {
+                const raw = localStorage.getItem(VOTED_ACTIVITIES_STORAGE_KEY);
+                if (!raw) return new Set();
+                const parsed = JSON.parse(raw);
+                if (!Array.isArray(parsed)) return new Set();
+                return new Set(parsed.filter(value => Number.isInteger(value) && value > 0));
+            } catch {
+                return new Set();
+            }
+        }
+
+        function saveVotedActivities() {
+            localStorage.setItem(VOTED_ACTIVITIES_STORAGE_KEY, JSON.stringify([...votedActivities]));
+        }
 
         function setFormStatus(id, message, isError = false) {
             const el = document.getElementById(id);
@@ -271,6 +289,7 @@
             }
 
             activities.forEach(activity => {
+                const hasVoted = votedActivities.has(activity.id);
                 const card = document.createElement('article');
                 card.className = 'activity-card';
                 card.innerHTML = `
@@ -278,7 +297,9 @@
                     <p>${escapeHtml(activity.description || 'No description provided.')}</p>
                     <p class="meta">Submitted by ${escapeHtml(activity.author || 'Anonymous')} · ${new Date(activity.createdAt).toLocaleString()}</p>
                     <div class="activity-actions">
-                        <button type="button" data-vote-id="${activity.id}">👍 ${activity.votes}</button>
+                        <button type="button" data-vote-id="${activity.id}" aria-pressed="${hasVoted}">
+                            ${hasVoted ? '👎 Remove vote' : '👍 Vote'} (${activity.votes})
+                        </button>
                     </div>
                     <form class="comment-form" data-comment-id="${activity.id}">
                         <input name="author" type="text" maxlength="80" placeholder="Name (optional)">
@@ -293,8 +314,22 @@
 
             document.querySelectorAll('[data-vote-id]').forEach(button => {
                 button.addEventListener('click', async () => {
+                    const activityId = Number(button.dataset.voteId);
+                    const hasVoted = votedActivities.has(activityId);
+                    const delta = hasVoted ? -1 : 1;
+
                     try {
-                        await api(`/api/activities/${button.dataset.voteId}/vote`, { method: 'POST' });
+                        await api(`/api/activities/${activityId}/vote`, {
+                            method: 'POST',
+                            body: JSON.stringify({ delta })
+                        });
+
+                        if (hasVoted) {
+                            votedActivities.delete(activityId);
+                        } else {
+                            votedActivities.add(activityId);
+                        }
+                        saveVotedActivities();
                         await refreshEverything();
                     } catch (error) {
                         alert(`Unable to vote: ${error.message}`);

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -47,14 +47,20 @@ export default {
       const voteMatch = url.pathname.match(/^\/api\/activities\/(\d+)\/vote$/);
       if (voteMatch && request.method === 'POST') {
         const activityId = Number(voteMatch[1]);
+        const payload = await request.json().catch(() => ({}));
+        const delta = Number(payload.delta);
+
+        if (![1, -1].includes(delta)) {
+          return json({ error: 'delta must be either 1 or -1.' }, 400);
+        }
 
         await env.DB
           .prepare(`
             UPDATE activities
-            SET votes = votes + 1
+            SET votes = MAX(0, votes + ?2)
             WHERE id = ?1
           `)
-          .bind(activityId)
+          .bind(activityId, delta)
           .run();
 
         return json({ ok: true });


### PR DESCRIPTION
### Motivation
- Fix incorrect voting behavior where clicks were not tied to the clicked activity and to allow anonymous users to toggle their vote per activity without signing in.
- Persist per-browser vote state so repeated clicks toggle the vote for the correct activity instead of cycling through the list.

### Description
- Added `VOTED_ACTIVITIES_STORAGE_KEY`, `loadVotedActivities()`, and `saveVotedActivities()` to track voted activity IDs in `localStorage` and manage them as a `Set` in the client (`planner.html`).
- Updated activity rendering to show a toggle button with `aria-pressed` and a label that switches between `👍 Vote` and `👎 Remove vote`, reflecting the local vote state for each activity.
- Changed the vote click handler to compute a `delta` (`+1` or `-1`), send it as JSON in the POST body to `/api/activities/:id/vote`, update the local `votedActivities` set, persist it, and refresh UI after each toggle.
- Updated the worker endpoint to accept a JSON `delta` of `1` or `-1`, validate the value, apply the delta to the specific activity, and use `MAX(0, votes + ?)` in SQL to prevent negative vote counts (`worker/src/index.js`).

### Testing
- Ran `node --check worker/src/index.js` to verify the worker file parses and is syntactically valid, and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e44eece8e4832c954355680daa4e6f)