### PR TITLE
Persist client vote state and add vote-delta support on server with non-negative enforcement

### DIFF
--- a/planner.html
+++ b/planner.html
@@ -117,8 +117,30 @@
         const timelineGrid = document.getElementById('timeline-grid');
         const masterTimeline = document.getElementById('master-timeline');
         const activitySelect = document.getElementById('timeline-activity');
+        const VOTED_ACTIVITIES_STORAGE_KEY = 'plannerVotedActivities';
 
         let activitiesCache = [];
+        let votedActivities = loadVotedActivities();
+
+        function loadVotedActivities() {
+            try {
+                const raw = localStorage.getItem(VOTED_ACTIVITIES_STORAGE_KEY);
+                if (!raw) return new Set();
+                const parsed = JSON.parse(raw);
+                if (!Array.isArray(parsed)) return new Set();
+                return new Set(
+                    parsed
+                        .map(value => Number(value))
+                        .filter(value => Number.isInteger(value) && value > 0)
+                );
+            } catch {
+                return new Set();
+            }
+        }
+
+        function saveVotedActivities() {
+            localStorage.setItem(VOTED_ACTIVITIES_STORAGE_KEY, JSON.stringify([...votedActivities]));
+        }
 
         function setFormStatus(id, message, isError = false) {
             const el = document.getElementById(id);
@@ -271,6 +293,8 @@
             }
 
             activities.forEach(activity => {
+                const activityId = Number(activity.id);
+                const hasVoted = votedActivities.has(activityId);
                 const card = document.createElement('article');
                 card.className = 'activity-card';
                 card.innerHTML = `
@@ -278,23 +302,37 @@
                     <p>${escapeHtml(activity.description || 'No description provided.')}</p>
                     <p class="meta">Submitted by ${escapeHtml(activity.author || 'Anonymous')} · ${new Date(activity.createdAt).toLocaleString()}</p>
                     <div class="activity-actions">
-                        <button type="button" data-vote-id="${activity.id}">👍 ${activity.votes}</button>
+                        <button type="button" data-vote-id="${activityId}" aria-pressed="${hasVoted}">
+                            ${hasVoted ? '👎 Remove vote' : '👍 Vote'} (${activity.votes})
+                        </button>
                     </div>
-                    <form class="comment-form" data-comment-id="${activity.id}">
+                    <form class="comment-form" data-comment-id="${activityId}">
                         <input name="author" type="text" maxlength="80" placeholder="Name (optional)">
                         <input name="body" type="text" maxlength="500" required placeholder="Add a reply for this activity thread...">
                         <button type="submit">Reply</button>
                     </form>
-                    <div class="comments" id="comments-${activity.id}"></div>
+                    <div class="comments" id="comments-${activityId}"></div>
                 `;
                 activityList.appendChild(card);
-                loadComments(activity.id, card.querySelector(`#comments-${activity.id}`));
-            });
+                loadComments(activityId, card.querySelector(`#comments-${activityId}`));
 
-            document.querySelectorAll('[data-vote-id]').forEach(button => {
-                button.addEventListener('click', async () => {
+                const voteButton = card.querySelector('[data-vote-id]');
+                voteButton.addEventListener('click', async () => {
+                    const hasVoted = votedActivities.has(activityId);
+                    const delta = hasVoted ? -1 : 1;
+
                     try {
-                        await api(`/api/activities/${button.dataset.voteId}/vote`, { method: 'POST' });
+                        await api(`/api/activities/${activityId}/vote`, {
+                            method: 'POST',
+                            body: JSON.stringify({ delta })
+                        });
+
+                        if (hasVoted) {
+                            votedActivities.delete(activityId);
+                        } else {
+                            votedActivities.add(activityId);
+                        }
+                        saveVotedActivities();
                         await refreshEverything();
                     } catch (error) {
                         alert(`Unable to vote: ${error.message}`);

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -47,14 +47,20 @@ export default {
       const voteMatch = url.pathname.match(/^\/api\/activities\/(\d+)\/vote$/);
       if (voteMatch && request.method === 'POST') {
         const activityId = Number(voteMatch[1]);
+        const payload = await request.json().catch(() => ({}));
+        const delta = Number(payload.delta);
+
+        if (![1, -1].includes(delta)) {
+          return json({ error: 'delta must be either 1 or -1.' }, 400);
+        }
 
         await env.DB
           .prepare(`
             UPDATE activities
-            SET votes = votes + 1
+            SET votes = MAX(0, votes + ?2)
             WHERE id = ?1
           `)
-          .bind(activityId)
+          .bind(activityId, delta)
           .run();
 
         return json({ ok: true });


### PR DESCRIPTION
### Motivation

- Let users toggle their vote on activities and persist that state in the browser so the UI reflects whether the user has already voted across sessions. 
- Allow vote removal (undo) from the client and propagate that intent to the server as a vote delta. 
- Ensure the server never reduces the stored vote count below zero.

### Description

- Add `VOTED_ACTIVITIES_STORAGE_KEY`, `loadVotedActivities`, and `saveVotedActivities` to persist a set of voted activity IDs in `localStorage`, and track `votedActivities` in the planner UI. 
- Render vote buttons with `aria-pressed` and context-aware labels (vote vs remove vote), use numeric `activityId` for DOM ids/datasets, and attach per-card click handlers that POST a JSON `{ delta }` to `/api/activities/:id/vote`. 
- Update the worker vote endpoint to parse an optional JSON body, validate that `delta` is either `1` or `-1`, and apply the change using `SET votes = MAX(0, votes + ?2)` to prevent negative vote counts. 
- Add defensive parsing for the vote endpoint payload and adjust comment element id usage to consistently use numeric activity IDs.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e44eece8e4832c954355680daa4e6f)