### PR TITLE
Use 12-hour formatting in planner timeline

### DIFF
--- a/planner.html
+++ b/planner.html
@@ -183,6 +183,17 @@
             return new Date(`${day}T00:00:00`).toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
         }
 
+        function formatTimelineTime(value) {
+            if (!value) return '';
+            const [hourString, minuteString = '00'] = String(value).split(':');
+            const hour = Number(hourString);
+            const minute = Number(minuteString);
+            if (!Number.isFinite(hour) || !Number.isFinite(minute)) return value;
+            const period = hour >= 12 ? 'PM' : 'AM';
+            const normalizedHour = hour % 12 || 12;
+            return `${normalizedHour}:${String(minute).padStart(2, '0')} ${period}`;
+        }
+
         async function api(path, options = {}) {
             const base = WORKER_BASE_URL.replace(/\/$/, '');
             const response = await fetch(`${base}${path}`, {
@@ -258,7 +269,7 @@
                         block.className = 'timeline-block';
                         block.innerHTML = `
                             <p><strong>${escapeHtml(entry.title)}</strong></p>
-                            <p>${escapeHtml(entry.startTime)} - ${escapeHtml(entry.endTime)}</p>
+                            <p>${escapeHtml(formatTimelineTime(entry.startTime))} - ${escapeHtml(formatTimelineTime(entry.endTime))}</p>
                             <p>by ${escapeHtml(entry.author || 'Anonymous')}</p>
                             <p>${totalSupport} supporter${totalSupport === 1 ? '' : 's'}</p>
                             <button type="button" data-second-id="${timelineEntryId}" aria-pressed="${hasSeconded}">
@@ -310,7 +321,7 @@
                 item.innerHTML = `
                     <div class="master-row-header">
                         <strong>${escapeHtml(row.title)}</strong>
-                        <span>${formatDate(row.day)} · ${escapeHtml(row.startTime)}-${escapeHtml(row.endTime)}</span>
+                        <span>${formatDate(row.day)} · ${escapeHtml(formatTimelineTime(row.startTime))}-${escapeHtml(formatTimelineTime(row.endTime))}</span>
                     </div>
                     <div class="master-meter">
                         <div class="master-meter-fill" style="width:${intensity}%"></div>


### PR DESCRIPTION
### Motivation
- The planner timeline currently shows times in 24-hour/HH:MM form and should display times in 12-hour AM/PM format for readability.

### Description
- Add a `formatTimelineTime` helper in `planner.html` that converts `HH:MM` (or similar) to `h:mm AM/PM` with sensible fallbacks.
- Use the helper when rendering per-day timeline suggestion cards so start/end times show in 12-hour format.
- Use the helper when rendering master timeline aggregate rows so aggregate entries also display 12-hour times.
- Ensure the helper tolerates missing or malformed values and returns the original input in that case.

### Testing
- Ran `git diff -- planner.html` to verify the change to `planner.html`, which showed the new helper and replacements and returned successfully.
- Ran `git status --short` to confirm the working tree is clean after applying the edits, which returned successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e45ad9cf84832cb9e58e5a9bfffd71)