### PR TITLE
Add collapsible check-in countdown to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,9 @@
     <meta http-equiv="Expires" content="0">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Llama Community Meetup - Wilmington 2026</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css?v=2">
 </head>
 <body>
@@ -30,6 +33,30 @@
                 });
             });
     </script>
+
+    <section class="checkin-countdown" aria-label="Check-in countdown">
+        <button class="countdown-toggle" id="countdownToggle" aria-expanded="true" aria-controls="countdownPanel">
+            Check-in Countdown
+            <span class="countdown-chevron" aria-hidden="true">▾</span>
+        </button>
+        <div class="countdown-panel" id="countdownPanel">
+            <p class="countdown-target">Until June 24, 2026 • 4:00 PM EST</p>
+            <div class="checkin-countdown-grid" role="timer" aria-live="polite">
+                <div class="checkin-countdown-block">
+                    <span class="checkin-countdown-value" id="countdownDays">0</span>
+                    <span class="checkin-countdown-label">Days</span>
+                </div>
+                <div class="checkin-countdown-block">
+                    <span class="checkin-countdown-value" id="countdownHours">0</span>
+                    <span class="checkin-countdown-label">Hours</span>
+                </div>
+                <div class="checkin-countdown-block">
+                    <span class="checkin-countdown-value" id="countdownMinutes">0</span>
+                    <span class="checkin-countdown-label">Minutes</span>
+                </div>
+            </div>
+        </div>
+    </section>
 
     <!-- Hero Section -->
     <section class="hero" id="home">
@@ -200,6 +227,49 @@
     </footer>
 
     <script>
+        (function setupCountdown() {
+            const targetDate = new Date('2026-06-24T16:00:00-05:00');
+            const daysEl = document.getElementById('countdownDays');
+            const hoursEl = document.getElementById('countdownHours');
+            const minutesEl = document.getElementById('countdownMinutes');
+            const toggleBtn = document.getElementById('countdownToggle');
+            const panel = document.getElementById('countdownPanel');
+            const chevron = toggleBtn.querySelector('.countdown-chevron');
+
+            function setUnitValues(diffMs) {
+                if (diffMs <= 0) {
+                    daysEl.textContent = '0';
+                    hoursEl.textContent = '0';
+                    minutesEl.textContent = '0';
+                    return;
+                }
+
+                const totalMinutes = Math.floor(diffMs / (1000 * 60));
+                const days = Math.floor(totalMinutes / (60 * 24));
+                const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
+                const minutes = totalMinutes % 60;
+
+                daysEl.textContent = String(days);
+                hoursEl.textContent = String(hours).padStart(2, '0');
+                minutesEl.textContent = String(minutes).padStart(2, '0');
+            }
+
+            function updateCountdown() {
+                const now = new Date();
+                setUnitValues(targetDate.getTime() - now.getTime());
+            }
+
+            toggleBtn.addEventListener('click', () => {
+                const isExpanded = toggleBtn.getAttribute('aria-expanded') === 'true';
+                toggleBtn.setAttribute('aria-expanded', String(!isExpanded));
+                panel.hidden = isExpanded;
+                chevron.textContent = isExpanded ? '▸' : '▾';
+            });
+
+            updateCountdown();
+            setInterval(updateCountdown, 1000);
+        })();
+
         // Smooth scrolling for navigation links
         document.querySelectorAll('a[href^="#"]').forEach(anchor => {
             anchor.addEventListener('click', function (e) {

--- a/style.css
+++ b/style.css
@@ -34,6 +34,84 @@ section {
     scroll-margin-top: 100px;
 }
 
+/* --- Homepage Check-in Countdown --- */
+.checkin-countdown {
+    max-width: 1200px;
+    margin: 1rem auto 0;
+    padding: 0 1rem;
+}
+
+.countdown-toggle {
+    width: 100%;
+    border: 2px solid #00ffff;
+    background: rgba(0, 0, 0, 0.9);
+    color: #00ffff;
+    font-family: 'Press Start 2P', cursive;
+    font-size: clamp(0.7rem, 1.2vw, 0.9rem);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    padding: 1rem;
+    border-radius: 12px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    cursor: pointer;
+}
+
+.countdown-toggle:hover {
+    border-color: #ff00ff;
+    color: #ff00ff;
+}
+
+.countdown-panel {
+    margin-top: 0.8rem;
+    border: 2px solid rgba(255, 0, 255, 0.9);
+    border-radius: 12px;
+    padding: 1rem 1.2rem 1.5rem;
+    background: radial-gradient(circle at top, rgba(35, 35, 35, 0.95), rgba(0, 0, 0, 0.95));
+}
+
+.countdown-target {
+    color: #ffff00;
+    text-align: center;
+    margin-bottom: 1rem;
+    font-size: clamp(0.75rem, 1.8vw, 1rem);
+    font-weight: 700;
+}
+
+.checkin-countdown-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.checkin-countdown-block {
+    text-align: center;
+    padding: 0.75rem;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.checkin-countdown-value {
+    display: block;
+    color: #ffffff;
+    font-family: 'Press Start 2P', cursive;
+    font-size: clamp(1.6rem, 4.2vw, 3.6rem);
+    line-height: 1.2;
+    text-shadow: 0 0 15px rgba(255, 255, 255, 0.35);
+}
+
+.checkin-countdown-label {
+    display: block;
+    margin-top: 0.6rem;
+    color: #00ffff;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 0.75rem;
+    font-weight: 700;
+}
+
 /* --- Navigation Styles --- */
 nav {
     position: fixed;
@@ -114,6 +192,15 @@ nav a:hover {
     nav a {
         font-size: 0.75rem;
         padding: 0.3rem 0.5rem;
+    }
+
+    .checkin-countdown-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .countdown-toggle {
+        font-size: 0.65rem;
+        padding: 0.9rem;
     }
 }
 


### PR DESCRIPTION
### Motivation
- Provide a visible, collapsible check-in countdown on the homepage to show days, hours, and minutes remaining until the meetup start time (June 24, 2026 at 4:00 PM EST). 

### Description
- Imported the `Press Start 2P` Google Font via `<link>` in `index.html` and applied it to the countdown UI. 
- Added a new collapsible section in `index.html` (`<section class="checkin-countdown">`) with accessible attributes (`aria-label`, `aria-controls`, `aria-expanded`, `aria-live`) and elements for `Days`, `Hours`, and `Minutes`. 
- Implemented an inline JavaScript IIFE in `index.html` that computes the remaining time to `2026-06-24T16:00:00-05:00`, updates the display every second, clamps values to `0` after the target, and toggles the panel open/closed while updating the chevron and `aria-expanded`. 
- Added responsive styles to `style.css` to make the countdown numbers white, very large, and use the `Press Start 2P` font, and to collapse the grid to a single column on mobile. 

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check errors and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebac928550832c87947f319e034a48)